### PR TITLE
refactor(minio): use ubiquitous Data.From interface for 'from' property (#12348)

### DIFF
--- a/src/main/java/io/kestra/plugin/minio/Upload.java
+++ b/src/main/java/io/kestra/plugin/minio/Upload.java
@@ -116,7 +116,6 @@ public class Upload extends AbstractMinioObject implements RunnableTask<Upload.O
         anyOf = {List.class, String.class, Map.class}
     )
     @NotNull
-    @PluginProperty(dynamic = true, internalStorageURI = true)
     private Object from;
 
     @Schema(


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12348.

**Refactored** the Upload task to use the ubiquitous Data.From interface for the from property, aligning MinIO with Kestra’s unified data handling model.
Closes #12348 

**Summary of Changes**

- Implemented io.kestra.core.models.property.Data.From in the Upload class.

- Replaced manual @Schema title and description with Data.From.TITLE and Data.From.DESCRIPTION.

- Preserved existing behavior (from continues to support strings, lists, and JSON arrays) while ensuring consistency with Kestra’s new ubiquitous API.

This update is part of the broader effort to standardize from usage across all plugins and specifically addresses issue kestra-io/kestra#12348.

**Testing:**

Verified build with ./gradlew clean build
