### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/minio/AbstractMinioObject.java
+++ b/src/main/java/io/kestra/plugin/minio/AbstractMinioObject.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -19,6 +20,7 @@ public abstract class AbstractMinioObject extends MinioConnection implements Abs
     @Schema(
         title = "The bucket name."
     )
+    @PluginProperty(group = "connection")
     protected Property<String> bucket;
 
 }

--- a/src/main/java/io/kestra/plugin/minio/Copy.java
+++ b/src/main/java/io/kestra/plugin/minio/Copy.java
@@ -74,19 +74,20 @@ public class Copy extends AbstractMinioObject implements RunnableTask<Copy.Outpu
     @Schema(
         title = "The source bucket and key."
     )
-    @PluginProperty
+    @PluginProperty(group = "source")
     private CopyObjectFrom from;
 
     @Schema(
         title = "The destination bucket and key."
     )
-    @PluginProperty
+    @PluginProperty(group = "destination")
     private CopyObject to;
 
     @Schema(
         title = "Whether to delete the source file after download."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> delete = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/CreateBucket.java
+++ b/src/main/java/io/kestra/plugin/minio/CreateBucket.java
@@ -13,6 +13,7 @@ import io.minio.errors.InvalidResponseException;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,6 +64,7 @@ public class CreateBucket extends AbstractMinioObject implements RunnableTask<Cr
     @Schema(
         title = "Specifies whether you want Object Lock to be enabled for the new bucket."
     )
+    @PluginProperty(group = "connection")
     private Property<Boolean> objectLockEnabledForBucket;
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/Delete.java
+++ b/src/main/java/io/kestra/plugin/minio/Delete.java
@@ -63,12 +63,13 @@ public class Delete extends AbstractMinioObject implements RunnableTask<Delete.O
     @Schema(
         title = "The key to delete."
     )
+    @PluginProperty(group = "connection")
     private Property<String> key;
 
     @Schema(
         title = "Indicates whether Object Lock should bypass Governance-mode restrictions to process this operation."
     )
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     private Property<Boolean> bypassGovernanceRetention;
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/DeleteList.java
+++ b/src/main/java/io/kestra/plugin/minio/DeleteList.java
@@ -92,17 +92,20 @@ public class DeleteList extends AbstractMinioObject implements RunnableTask<Dele
     @Schema(
         title = "Limits the response to keys that begin with the specified prefix."
     )
+    @PluginProperty(group = "source")
     private Property<String> prefix;
 
     @Schema(
         title = "A delimiter is a character you use to group keys."
     )
+    @PluginProperty(group = "processing")
     private Property<String> delimiter;
 
     @Schema(
         title = "Marker is where you want to start listing from.",
         description = "Start listing after this specified key. Marker can be any key in the bucket."
     )
+    @PluginProperty(group = "source")
     private Property<String> marker;
 
     @Schema(
@@ -110,6 +113,7 @@ public class DeleteList extends AbstractMinioObject implements RunnableTask<Dele
         description = "By default, the action returns up to 1,000 key names. The response might contain fewer keys but will never contain more."
     )
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<Integer> maxKeys = Property.ofValue(1000);
 
     @Schema(
@@ -118,6 +122,7 @@ public class DeleteList extends AbstractMinioObject implements RunnableTask<Dele
             "`regExp: .*` to match all files\n" +
             "`regExp: .*2020-01-0.\\\\.csv` to match files between 01 and 09 of january ending with `.csv`"
     )
+    @PluginProperty(group = "processing")
     protected Property<String> regexp;
 
     @Schema(
@@ -130,13 +135,14 @@ public class DeleteList extends AbstractMinioObject implements RunnableTask<Dele
     @Schema(
         title = "Number of concurrent parallels deletion"
     )
-    @PluginProperty
+    @PluginProperty(group = "execution")
     private Integer concurrent;
 
     @Schema(
         title = "raise an error if the file is not found"
     )
     @Builder.Default
+    @PluginProperty(group = "reliability")
     private final Property<Boolean> errorOnEmpty = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/Download.java
+++ b/src/main/java/io/kestra/plugin/minio/Download.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -78,11 +79,13 @@ public class Download extends AbstractMinioObject implements RunnableTask<Downlo
     @Schema(
         title = "The key of a file to download."
     )
+    @PluginProperty(group = "connection")
     private Property<String> key;
 
     @Schema(
         title = "The specific version of the object."
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> versionId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/Downloads.java
+++ b/src/main/java/io/kestra/plugin/minio/Downloads.java
@@ -92,17 +92,20 @@ public class Downloads extends AbstractMinioObject implements RunnableTask<Downl
     @Schema(
         title = "Limits the response to keys that begin with the specified prefix."
     )
+    @PluginProperty(group = "source")
     private Property<String> prefix;
 
     @Schema(
         title = "A delimiter is a character you use to group keys."
     )
+    @PluginProperty(group = "processing")
     private Property<String> delimiter;
 
     @Schema(
         title = "Marker is where you want to start listing from.",
         description = "Start listing after this specified key. Marker can be any key in the bucket."
     )
+    @PluginProperty(group = "source")
     private Property<String> marker;
 
     @Schema(
@@ -110,6 +113,7 @@ public class Downloads extends AbstractMinioObject implements RunnableTask<Downl
         description = "By default, the action returns up to 1,000 key names. The response might contain fewer keys but will never contain more."
     )
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<Integer> maxKeys = Property.ofValue(1000);
 
     @Schema(
@@ -118,6 +122,7 @@ public class Downloads extends AbstractMinioObject implements RunnableTask<Downl
             "`regExp: .*` to match all files\n" +
             "`regExp: .*2020-01-0.\\\\.csv` to match files between 01 and 09 of january ending with `.csv`"
     )
+    @PluginProperty(group = "processing")
     protected Property<String> regexp;
 
     @Schema(
@@ -130,6 +135,7 @@ public class Downloads extends AbstractMinioObject implements RunnableTask<Downl
         title = "The action to perform on the retrieved files. If using 'NONE' make sure to handle the files inside your flow to avoid infinite triggering."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Action> action;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/minio/List.java
+++ b/src/main/java/io/kestra/plugin/minio/List.java
@@ -23,6 +23,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -87,22 +88,26 @@ public class List extends AbstractMinioObject implements RunnableTask<List.Outpu
     @Schema(
         title = "Limits the response to keys that begin with the specified prefix."
     )
+    @PluginProperty(group = "source")
     private Property<String> prefix;
 
     @Schema(
         title = "Limits the response to keys that ends with the specified string."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> startAfter;
 
     @Schema(
         title = "A delimiter is a character you use to group keys."
     )
+    @PluginProperty(group = "processing")
     private Property<String> delimiter;
 
     @Schema(
         title = "Marker is where you want to start listing from.",
         description = "Start listing after this specified key. Marker can be any key in the bucket."
     )
+    @PluginProperty(group = "source")
     private Property<String> marker;
 
     @Schema(
@@ -110,6 +115,7 @@ public class List extends AbstractMinioObject implements RunnableTask<List.Outpu
         description = "By default, the action returns up to 1,000 key names. The response might contain fewer keys but will never contain more."
     )
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<Integer> maxKeys = Property.ofValue(1000);
 
     @Schema(
@@ -118,24 +124,28 @@ public class List extends AbstractMinioObject implements RunnableTask<List.Outpu
             "`regExp: .*` to match all files\n" +
             "`regExp: .*2020-01-0.\\\\.csv` to match files between 01 and 09 of january ending with `.csv`"
     )
+    @PluginProperty(group = "processing")
     protected Property<String> regexp;
 
     @Schema(
         title = "The type of objects to filter: files, directory, or both."
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     protected final Property<Filter> filter = Property.ofValue(Filter.BOTH);
 
     @Schema(
         title = "Indicates whether it should look into subfolders."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     public Property<Boolean> recursive = Property.ofValue(true);
 
     @Schema(
         title = "Indicates whether task should include versions in output."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     public Property<Boolean> includeVersions = Property.ofValue(true);
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/MinioConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/minio/MinioConnectionInterface.java
@@ -13,41 +13,45 @@ public interface MinioConnectionInterface {
     @Schema(
         title = "URL to the MinIO endpoint."
     )
+    @PluginProperty(group = "connection")
     Property<String> getEndpoint();
 
     @Schema(
         title = "Access Key Id for authentication."
     )
+    @PluginProperty(group = "advanced")
     Property<String> getAccessKeyId();
 
     @Schema(
         title = "Secret Key Id for authentication."
     )
+    @PluginProperty(group = "advanced")
     Property<String> getSecretKeyId();
 
     @Schema(
         title = "MinIO region with which the SDK should communicate."
     )
+    @PluginProperty(group = "connection")
     Property<String> getRegion();
 
     @Schema(
         title = "Client PEM certificate content",
         description = "PEM client certificate as text, used to authenticate the connection to MinIO (mTLS)."
     )
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     Property<String> getClientPem();
 
     @Schema(
         title = "CA PEM certificate content",
         description = "CA certificate as text, used to verify SSL/TLS connections to custom MinIO endpoints."
     )
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     Property<String> getCaPem();
 
     @Schema(
         title = "SSL/TLS configuration options"
     )
-    @PluginProperty
+    @PluginProperty(group = "connection")
     SslOptions getSsl();
 
     default MinioConnection.MinioClientConfig minioClientConfig(final RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/minio/Trigger.java
+++ b/src/main/java/io/kestra/plugin/minio/Trigger.java
@@ -26,6 +26,7 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.models.triggers.StatefulTriggerService.*;
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -182,12 +183,14 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
         title = "Client PEM certificate content",
         description = "PEM client certificate as text, used to authenticate the connection to enterprise AI endpoints."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> clientPem;
 
     @Schema(
         title = "CA PEM certificate content",
         description = "CA certificate as text, used to verify SSL/TLS connections when using custom endpoints."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> caPem;
 
     protected SslOptions ssl;

--- a/src/main/java/io/kestra/plugin/minio/Upload.java
+++ b/src/main/java/io/kestra/plugin/minio/Upload.java
@@ -34,6 +34,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -110,6 +111,7 @@ public class Upload extends AbstractMinioObject implements RunnableTask<Upload.O
         title = "The key where to upload the file.",
         description = "a full key (with filename) or the directory path if from is multiple files."
     )
+    @PluginProperty(group = "connection")
     private Property<String> key;
 
     @Schema(
@@ -118,16 +120,19 @@ public class Upload extends AbstractMinioObject implements RunnableTask<Upload.O
         anyOf = { List.class, String.class, Map.class }
     )
     @NotNull
+    @PluginProperty(group = "source")
     private Object from;
 
     @Schema(
         title = "A standard MIME type describing the format of the contents."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> contentType;
 
     @Schema(
         title = "A map of metadata to store with the object."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> metadata;
 
     @Override

--- a/src/main/java/io/kestra/plugin/minio/model/ObjectOutput.java
+++ b/src/main/java/io/kestra/plugin/minio/model/ObjectOutput.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @Getter
@@ -13,11 +14,13 @@ public class ObjectOutput {
     @Schema(
         title = "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL."
     )
+    @PluginProperty(group = "advanced")
     private String eTag;
 
     @Schema(
         title = "The version of the object."
     )
+    @PluginProperty(group = "advanced")
     private String versionId;
 
 }


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712