### PR TITLE
refactor: rename deprecated retry property maxAttempt to maxAttempts

### DIFF
--- a/src/test/resources/sanity-checks/all_minio.yaml
+++ b/src/test/resources/sanity-checks/all_minio.yaml
@@ -45,7 +45,7 @@ tasks:
     retry:
       type: constant
       interval: PT2S
-      maxAttempt: 30
+      maxAttempts: 30
 
   - id: create_source_bucket
     type: io.kestra.plugin.minio.CreateBucket


### PR DESCRIPTION
Renames the deprecated retry property maxAttempt to maxAttempts