### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/minio/AbstractMinio.java
+++ b/src/main/java/io/kestra/plugin/minio/AbstractMinio.java
@@ -75,6 +75,12 @@ public interface AbstractMinio extends MinioConnectionInterface {
 
     private static OkHttpClient buildHttpClient(MinioConnection.MinioClientConfig config, RunContext runContext) throws Exception {
         if (config.sslOptions() != null && runContext.render(config.sslOptions().getInsecureTrustAllCertificates()).as(Boolean.class).orElse(false)) {
+            runContext.logger().warn(
+                "MinIO client is configured with 'ssl.insecureTrustAllCertificates=true': TLS certificate validation " +
+                    "and hostname verification are disabled. This makes the connection vulnerable to man-in-the-middle " +
+                    "attacks and should only be used for local development or testing against trusted networks."
+            );
+
             SSLContext sslContext = SSLContexts.custom()
                 .loadTrustMaterial(null, (chain, authType) -> true)
                 .build();

--- a/src/main/java/io/kestra/plugin/minio/MinioConnection.java
+++ b/src/main/java/io/kestra/plugin/minio/MinioConnection.java
@@ -20,7 +20,9 @@ public abstract class MinioConnection extends Task implements MinioConnectionInt
 
     protected Property<String> region;
 
+    @ToString.Exclude
     protected Property<String> accessKeyId;
+    @ToString.Exclude
     protected Property<String> secretKeyId;
 
     protected Property<String> endpoint;

--- a/src/main/java/io/kestra/plugin/minio/MinioConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/minio/MinioConnectionInterface.java
@@ -38,7 +38,7 @@ public interface MinioConnectionInterface {
         title = "Client PEM certificate content",
         description = "PEM client certificate as text, used to authenticate the connection to MinIO (mTLS)."
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(secret = true, group = "advanced")
     Property<String> getClientPem();
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/minio/Trigger.java
+++ b/src/main/java/io/kestra/plugin/minio/Trigger.java
@@ -144,8 +144,10 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     @Builder.Default
     private final Duration interval = Duration.ofSeconds(60);
 
+    @ToString.Exclude
     protected Property<String> accessKeyId;
 
+    @ToString.Exclude
     protected Property<String> secretKeyId;
 
     protected Property<String> region;


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Lombok `@ToString` leaks `accessKeyId` and `secretKeyId` in `MinioConnection` — `src/main/java/io/kestra/plugin/minio/MinioConnection.java:23-24` — Added `@ToString.Exclude` to both fields so credentials no longer appear in generated `toString()` output.
- **HIGH** — Lombok `@ToString` leaks `accessKeyId` and `secretKeyId` in `Trigger` — `src/main/java/io/kestra/plugin/minio/Trigger.java:147,149` — Added `@ToString.Exclude` to both fields (redeclared directly on `Trigger`, so the parent-class fix alone was insufficient).
- **MEDIUM** — `clientPem` field not annotated `@PluginProperty(secret = true)` despite containing TLS private key material — `src/main/java/io/kestra/plugin/minio/MinioConnectionInterface.java:41` — Added `secret = true` to the existing `@PluginProperty` annotation on `getClientPem()`.
- **MEDIUM** — User-configurable complete TLS bypass disables both certificate validation and hostname verification — `src/main/java/io/kestra/plugin/minio/AbstractMinio.java:77` — Added a runtime warning log emitted whenever `ssl.insecureTrustAllCertificates=true` is used, giving operators an audit trail when this insecure mode is activated, without removing the documented dev/test escape hatch.

No LOW findings were reported in this audit.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-minio/issues/140
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
